### PR TITLE
Add character descriptions for AI

### DIFF
--- a/character.py
+++ b/character.py
@@ -25,6 +25,7 @@ class Character:
         leadership: int = 50,
         intelligence: int = 50,
         resilience: int = 50,
+        description: str = "",
         friends: List["Character"] = None,
         enemies: List["Character"] = None,
         special_properties: List[Callable[["Character", "Character"], bool]] = None
@@ -36,6 +37,7 @@ class Character:
             leadership (int, optional): Leadership attribute (0-100). Defaults to 50.
             intelligence (int, optional): Intelligence attribute (0-100). Defaults to 50.
             resilience (int, optional): Resilience attribute (0-100). Defaults to 50.
+            description (str, optional): Textual description of the character.
             friends (List[Character], optional): Initial list of friends. Defaults to empty list.
             enemies (List[Character], optional): Initial list of enemies. Defaults to empty list.
             special_properties (List[Callable], optional): Special behavior predicates. 
@@ -51,6 +53,7 @@ class Character:
         # each property is a predicate (self, other) → bool
         self.special_properties = special_properties or []
         self.current_emotion = Emotion.NEUTRAL
+        self.description = description
 
     def can_talk_to(self, other: "Character") -> bool:
         """Determine if this character can talk to another character.

--- a/chatbot.py
+++ b/chatbot.py
@@ -80,7 +80,9 @@ class OpenAIAdapter(AIAdapter):
             str: The generated response text
         """
         # Create a system message that describes the character
-        system_message = f"""You are roleplaying as {character.name}, a character with the following attributes:
+        system_message = f"""You are roleplaying as {character.name}.
+Description: {character.description}
+The character has the following attributes:
 - Leadership: {character.leadership}/100
 - Intelligence: {character.intelligence}/100
 - Resilience: {character.resilience}/100

--- a/game.py
+++ b/game.py
@@ -43,8 +43,9 @@ class Game:
 
         Creates Character instances for all canonical characters defined in the CHARACTERS
         constant. Each character is initialized with specific attributes (leadership,
-        intelligence, resilience) and special properties as defined in the character_attributes
-        dictionary.
+        intelligence, resilience) and special properties as well as a descriptive
+        text explaining their personality and background. Descriptions are used
+        by the chatbot to generate more authentic dialogue.
 
         The created characters are stored in the self.characters dictionary, keyed by
         their names.
@@ -53,47 +54,56 @@ class Game:
             "Monstradamus": {
                 "leadership": 85,
                 "intelligence": 95,
-                "resilience": 75
+                "resilience": 75,
+                "description": "A prophetic monster whisperer who speaks in riddles and often sees patterns others miss."
             },
             "IsoldA": {
                 "leadership": 60,
                 "intelligence": 75,
-                "resilience": 65
+                "resilience": 65,
+                "description": "A stoic warrior priestess devoted to ancient traditions and inner harmony."
             },
             "Nutscracker": {
                 "leadership": 70,
                 "intelligence": 90,
-                "resilience": 55
+                "resilience": 55,
+                "description": "An eccentric tactician whose schemes are as unpredictable as they are effective."
             },
             "Organizm(-:": {
                 "leadership": 40,
                 "intelligence": 65,
-                "resilience": 45
+                "resilience": 45,
+                "description": "A mysterious being of questionable origin, fascinated by the mechanics of life itself."
             },
             "Theseus": {
                 "leadership": 80,
                 "intelligence": 70,
-                "resilience": 75
+                "resilience": 75,
+                "description": "A brave hero with a keen sense of justice, destined to confront the labyrinth's horrors."
             },
             "Ariadne": {
                 "leadership": 65,
                 "intelligence": 85,
-                "resilience": 65
+                "resilience": 65,
+                "description": "A brilliant strategist and master of threads, forever tied to the labyrinth's secrets."
             },
             "UGLI 666": {
                 "leadership": 55,
                 "intelligence": 60,
-                "resilience": 45
+                "resilience": 45,
+                "description": "A rebellious outcast with a penchant for dark humor and underground rumors."
             },
             "Romeo-y-Cohiba": {
                 "leadership": 55,
                 "intelligence": 65,
-                "resilience": 35
+                "resilience": 35,
+                "description": "A charming rogue who masks insecurity with bravado and grandiose tales."
             },
             "Sartrik": {
                 "leadership": 50,
                 "intelligence": 95,
                 "resilience": 55,
+                "description": "A brooding philosopher constantly questioning reality and motives.",
                 "special_properties": [lambda self, other: other.intelligence > 80]
             }
         }


### PR DESCRIPTION
## Summary
- enrich `Game.initialize_characters` with textual descriptions for every character
- store description on the `Character` object
- include description in the system prompt used by the `Chatbot` OpenAI adapter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68839a9e9a1883209b5678ec62b9de3b